### PR TITLE
Grant gh-pages workflow push access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/deployAction
+++ b/.github/workflows/deployAction
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the GitHub Pages deploy workflow the permissions it needs to push

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d0e373e094832fb8a1f7c1f4953054