### PR TITLE
Configure Vite base path for GitHub Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/deployAction
+++ b/.github/workflows/deployAction
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: mode === 'production' ? '/idle-mining-/' : '/',
       plugins: [react()],
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),


### PR DESCRIPTION
## Summary
- configure the Vite build to use the repository subpath when running in production so assets resolve on GitHub Pages

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0e373e094832fb8a1f7c1f4953054