### PR TITLE
Fix manager skill points awarded per 10 levels

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -28,7 +28,7 @@ export const BASE_MARKET_MANAGER_COST = 30000;
 export const MARKET_MANAGER_BONUS = 0.01; // 1% value boost per level
 
 // Skill System Constants
-export const SKILL_POINT_MILESTONES = [10, 25, 50, 75, 100];
+export const MANAGER_SKILL_POINT_INTERVAL = 10;
 
 // Mineshaft Skill Effects
 export const GEOLOGIST_EYE_CHANCE = 0.02; // 2%

--- a/managers/GameManager.ts
+++ b/managers/GameManager.ts
@@ -13,7 +13,7 @@ import {
     ELEVATOR_MANAGER_BONUS,
     BASE_MARKET_MANAGER_COST,
     MARKET_MANAGER_BONUS,
-    SKILL_POINT_MILESTONES,
+    MANAGER_SKILL_POINT_INTERVAL,
     GEOLOGIST_EYE_CHANCE,
     GEOLOGIST_EYE_MULTIPLIER,
     DEEPER_VEINS_STORAGE_BONUS,
@@ -500,10 +500,13 @@ export class GameManager {
         }
     }
     
-    private checkAndAwardSkillPoint(manager: { level: number, skillPoints: number }, newLevel: number) {
-        const currentMilestonesPassed = SKILL_POINT_MILESTONES.filter(m => manager.level < m && newLevel >= m).length;
-        if (currentMilestonesPassed > 0) {
-            manager.skillPoints += currentMilestonesPassed;
+    private checkAndAwardSkillPoint(manager: { managerLevel: number; skillPoints: number }, newLevel: number) {
+        const previousThreshold = Math.floor(manager.managerLevel / MANAGER_SKILL_POINT_INTERVAL);
+        const newThreshold = Math.floor(newLevel / MANAGER_SKILL_POINT_INTERVAL);
+        const pointsEarned = newThreshold - previousThreshold;
+
+        if (pointsEarned > 0) {
+            manager.skillPoints += pointsEarned;
         }
     }
 


### PR DESCRIPTION
## Summary
- replace the hard-coded milestone list with a reusable manager skill point interval constant
- award manager skill points based on manager level thresholds so a point is gained for every 10 levels reached

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1618a2428832f88f76ab093c44bd3