### PR TITLE
Add auto upgrade system for buildings and managers

### DIFF
--- a/components/Ground.tsx
+++ b/components/Ground.tsx
@@ -35,20 +35,28 @@ interface GroundProps {
     onOpenMarketManagerDetails: () => void;
     onOpenElevatorManagerDetails: () => void;
     onOpenCartManagerDetails: () => void;
+    onToggleMarketAutoUpgrade: () => void;
+    onToggleElevatorAutoUpgrade: () => void;
+    onToggleCartAutoUpgrade: () => void;
     marketUpgradeCost: number;
     elevatorUpgradeCost: number;
     cartUpgradeCost: number;
     formatNumber: (num: number) => string;
     cash: number;
     resources: Resource[];
+    isMarketAutoUpgrading: boolean;
+    isElevatorAutoUpgrading: boolean;
+    isCartAutoUpgrading: boolean;
 }
 
-const Ground: React.FC<GroundProps> = ({ 
+const Ground: React.FC<GroundProps> = ({
     market, elevator, cart,
     onUpgradeMarket, onUpgradeElevator, onUpgradeCart,
     onOpenMarketManagerDetails, onOpenElevatorManagerDetails, onOpenCartManagerDetails,
+    onToggleMarketAutoUpgrade, onToggleElevatorAutoUpgrade, onToggleCartAutoUpgrade,
     marketUpgradeCost, elevatorUpgradeCost, cartUpgradeCost,
-    formatNumber, cash, resources
+    formatNumber, cash, resources,
+    isMarketAutoUpgrading, isElevatorAutoUpgrading, isCartAutoUpgrading
 }) => {
     const [floatingTexts, setFloatingTexts] = useState<{ id: number; amount: number }[]>([]);
     const resourceMap = useMemo(() => new Map(resources.map(r => [r.id, r])), [resources]);
@@ -112,12 +120,25 @@ const Ground: React.FC<GroundProps> = ({
                 <div className="bg-slate-800/80 rounded-md px-3 py-1 text-sm text-white font-semibold w-full shadow-inner">
                     Storage: {formatNumber(totalElevatorStorage)}
                 </div>
-                <UpgradeButton 
-                    onClick={onUpgradeElevator} 
-                    cost={elevatorUpgradeCost}
-                    disabled={cash < elevatorUpgradeCost}
-                    formatNumber={formatNumber}
-                />
+                <div className="w-full space-y-1">
+                    <UpgradeButton
+                        onClick={onUpgradeElevator}
+                        cost={elevatorUpgradeCost}
+                        disabled={cash < elevatorUpgradeCost}
+                        formatNumber={formatNumber}
+                    />
+                    <button
+                        onClick={onToggleElevatorAutoUpgrade}
+                        aria-pressed={isElevatorAutoUpgrading}
+                        className={`w-full py-1.5 text-xs font-bold rounded-md border transition-colors duration-150 ${
+                            isElevatorAutoUpgrading
+                                ? 'bg-purple-500 text-white border-purple-300 shadow-md'
+                                : 'bg-black/30 text-gray-200 border-black/40 hover:bg-black/40'
+                        }`}
+                    >
+                        AUTO {isElevatorAutoUpgrading ? 'ON' : 'OFF'}
+                    </button>
+                </div>
             </div>
 
             {/* Pipeline Panel */}
@@ -156,12 +177,25 @@ const Ground: React.FC<GroundProps> = ({
                  <div className="bg-slate-800/80 rounded-md px-3 py-1 text-sm text-white font-semibold w-full shadow-inner">
                     Load: {formatNumber(getTotalResourceCount(cart.load))}
                 </div>
-                <UpgradeButton
-                    onClick={onUpgradeCart}
-                    cost={cartUpgradeCost}
-                    disabled={cash < cartUpgradeCost}
-                    formatNumber={formatNumber}
-                />
+                <div className="w-full space-y-1">
+                    <UpgradeButton
+                        onClick={onUpgradeCart}
+                        cost={cartUpgradeCost}
+                        disabled={cash < cartUpgradeCost}
+                        formatNumber={formatNumber}
+                    />
+                    <button
+                        onClick={onToggleCartAutoUpgrade}
+                        aria-pressed={isCartAutoUpgrading}
+                        className={`w-full py-1.5 text-xs font-bold rounded-md border transition-colors duration-150 ${
+                            isCartAutoUpgrading
+                                ? 'bg-purple-500 text-white border-purple-300 shadow-md'
+                                : 'bg-black/30 text-gray-200 border-black/40 hover:bg-black/40'
+                        }`}
+                    >
+                        AUTO {isCartAutoUpgrading ? 'ON' : 'OFF'}
+                    </button>
+                </div>
             </div>
 
             {/* Market Panel */}
@@ -197,12 +231,25 @@ const Ground: React.FC<GroundProps> = ({
                  <div className="bg-blue-600 text-white text-sm font-bold rounded-md py-1 px-4 w-full shadow-sm">
                     LEVEL {market.level}
                 </div>
-                <UpgradeButton 
-                    onClick={onUpgradeMarket} 
-                    cost={marketUpgradeCost} 
-                    formatNumber={formatNumber} 
-                    disabled={cash < marketUpgradeCost} 
-                />
+                <div className="w-full space-y-1">
+                    <UpgradeButton
+                        onClick={onUpgradeMarket}
+                        cost={marketUpgradeCost}
+                        formatNumber={formatNumber}
+                        disabled={cash < marketUpgradeCost}
+                    />
+                    <button
+                        onClick={onToggleMarketAutoUpgrade}
+                        aria-pressed={isMarketAutoUpgrading}
+                        className={`w-full py-1.5 text-xs font-bold rounded-md border transition-colors duration-150 ${
+                            isMarketAutoUpgrading
+                                ? 'bg-purple-500 text-white border-purple-300 shadow-md'
+                                : 'bg-black/30 text-gray-200 border-black/40 hover:bg-black/40'
+                        }`}
+                    >
+                        AUTO {isMarketAutoUpgrading ? 'ON' : 'OFF'}
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/components/Manager.tsx
+++ b/components/Manager.tsx
@@ -7,6 +7,7 @@ interface ManagerProps {
 
 const getManagerIconStyle = (level: number) => {
     if (level === 0) return 'grayscale opacity-70';
+    if (level >= 200) return 'drop-shadow-[0_0_12px_rgba(167,139,250,0.85)] text-purple-300';
     if (level >= 100) return 'drop-shadow-[0_0_10px_rgba(236,72,153,0.8)] text-pink-400';
     if (level >= 50) return 'drop-shadow-[0_0_8px_rgba(250,204,21,0.7)] text-yellow-300';
     if (level >= 10) return 'drop-shadow-[0_0_6px_rgba(59,130,246,0.6)] text-blue-400';

--- a/components/ManagerDetailModal.tsx
+++ b/components/ManagerDetailModal.tsx
@@ -14,6 +14,8 @@ interface ManagerDetailModalProps {
     bonusInfo: { description: string; value: string; };
     formatNumber: (num: number) => string;
     cash: number;
+    isAutoUpgradingManager: boolean;
+    onToggleAutoUpgrade: () => void;
 }
 
 const getManagerTitle = (info: ModalManagerInfo) => {
@@ -25,9 +27,10 @@ const getManagerTitle = (info: ModalManagerInfo) => {
     }
 }
 
-const ManagerDetailModal: React.FC<ManagerDetailModalProps> = ({ 
+const ManagerDetailModal: React.FC<ManagerDetailModalProps> = ({
     isOpen, onClose, onUpgrade, onOpenSkills, managerInfo,
-    gameManager, bonusInfo, formatNumber, cash
+    gameManager, bonusInfo, formatNumber, cash,
+    isAutoUpgradingManager, onToggleAutoUpgrade
 }) => {
     const [isUpgrading, setIsUpgrading] = useState(false);
     const [upgradeAmount, setUpgradeAmount] = useState<UpgradeAmount>(1);
@@ -95,7 +98,19 @@ const ManagerDetailModal: React.FC<ManagerDetailModalProps> = ({
                         {!isHire && upgradeInfo.levels > 0 && <span className="ml-1.5 text-xs font-bold bg-yellow-400 text-black rounded px-1.5 py-0.5">+{upgradeInfo.levels}</span>}
                         <span className="ml-2">(${formatNumber(upgradeInfo.cost)})</span>
                     </button>
-                    
+
+                    <button
+                        onClick={onToggleAutoUpgrade}
+                        className={`w-full py-2 text-sm font-bold rounded-lg border transition-colors duration-150 ${
+                            isAutoUpgradingManager
+                                ? 'bg-purple-600 border-purple-400 text-white shadow-md'
+                                : 'bg-black/30 border-black/40 text-gray-200 hover:bg-black/40'
+                        }`}
+                        aria-pressed={isAutoUpgradingManager}
+                    >
+                        {isAutoUpgradingManager ? 'Auto Upgrade Active' : 'Enable Auto Upgrade'}
+                    </button>
+
                     <button
                         onClick={onOpenSkills}
                         disabled={data.managerLevel === 0}

--- a/components/MineShaft.tsx
+++ b/components/MineShaft.tsx
@@ -17,13 +17,15 @@ interface MineShaftProps {
     upgradeDisabled: boolean;
     managerBonusMultiplier: number;
     resource: Resource | undefined;
+    isAutoUpgrading: boolean;
+    onToggleAutoUpgrade: () => void;
 }
 
-const MineShaftComponent: React.FC<MineShaftProps> = ({ 
+const MineShaftComponent: React.FC<MineShaftProps> = ({
     shaft, onUpgrade, onOpenManagerDetails,
-    upgradeCost, formatNumber, upgradeDisabled, 
+    upgradeCost, formatNumber, upgradeDisabled,
     managerBonusMultiplier, production, maxResources,
-    resource
+    resource, isAutoUpgrading, onToggleAutoUpgrade
 }) => {
     
     const resourcePercentage = maxResources > 0 ? (shaft.resources / maxResources) * 100 : 0;
@@ -90,6 +92,17 @@ const MineShaftComponent: React.FC<MineShaftProps> = ({
                     disabled={upgradeDisabled}
                     formatNumber={formatNumber}
                 />
+                <button
+                    onClick={onToggleAutoUpgrade}
+                    aria-pressed={isAutoUpgrading}
+                    className={`w-full py-1.5 text-xs font-bold rounded-md border transition-colors duration-150 ${
+                        isAutoUpgrading
+                            ? 'bg-purple-500 text-white border-purple-300 shadow-md'
+                            : 'bg-black/30 text-gray-200 border-black/40 hover:bg-black/40'
+                    }`}
+                >
+                    AUTO {isAutoUpgrading ? 'ON' : 'OFF'}
+                </button>
             </div>
         </div>
     );

--- a/constants.ts
+++ b/constants.ts
@@ -92,6 +92,7 @@ export const INITIAL_GAME_STATE: GameState = {
         unlockedSkills: [],
     },
     resources: initialResources,
+    autoUpgradeTarget: null,
 };
 
 // --- Skill Definitions ---

--- a/services/gameService.ts
+++ b/services/gameService.ts
@@ -83,6 +83,10 @@ export const loadGame = (): SavedGame | null => {
                     if (parsed.gameState.cart.unlockedSkills === undefined) parsed.gameState.cart.unlockedSkills = [];
                 }
 
+                if (parsed.gameState.autoUpgradeTarget === undefined) {
+                    parsed.gameState.autoUpgradeTarget = null;
+                }
+
                 return parsed as SavedGame;
             }
         }

--- a/types.ts
+++ b/types.ts
@@ -1,5 +1,14 @@
 import { Resource } from './services/resourceService';
 
+// --- Auto Upgrade ---
+export type AutoUpgradeSubject = 'level' | 'manager';
+
+export type AutoUpgradeTarget =
+    | { type: 'mineshaft'; id: number; subject: AutoUpgradeSubject }
+    | { type: 'elevator'; subject: AutoUpgradeSubject }
+    | { type: 'market'; subject: AutoUpgradeSubject }
+    | { type: 'cart'; subject: AutoUpgradeSubject };
+
 // --- Skills ---
 export enum MineShaftSkill {
     GEOLOGISTS_EYE = 'geologists-eye',
@@ -95,6 +104,7 @@ export interface GameState {
     cart: CartState;
     market: MarketState;
     resources: Resource[];
+    autoUpgradeTarget: AutoUpgradeTarget | null;
 }
 
 // --- UI Types ---


### PR DESCRIPTION
## Summary
- add auto-upgrade toggles for mineshafts, elevator, pipeline, market, and their managers so players can automate single-level upgrades
- persist the selected auto-upgrade target in game state and process it each tick to hire/level managers while continuing to award skill points up to high levels
- refresh UI styling to highlight level 200 managers and migrate existing saves to support the new automation state

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3b40c67c4832fbc9e5f82d36170b7