### PR TITLE
Add multi-level manager skills with scaling effects

### DIFF
--- a/constants.ts
+++ b/constants.ts
@@ -3,6 +3,7 @@ import { generateResources } from './services/resourceService';
 
 export const GAME_TICK_MS = 100;
 export const MAX_SHAFTS = 12;
+export const MAX_SKILL_LEVEL = 5;
 
 export const BASE_SHAFT_COST = 100;
 export const SHAFT_COST_MULTIPLIER = 20; // Increased to balance 10x production
@@ -60,7 +61,16 @@ const initialResources = generateResources(MAX_SHAFTS); // Generate resources fo
 export const INITIAL_GAME_STATE: GameState = {
     cash: 1000,
     mineShafts: [
-        { id: 0, level: 1, resources: 0, resourceId: initialResources[0].id, y: SHAFT_POSITION_Y_OFFSET, managerLevel: 0, skillPoints: 0, unlockedSkills: [] },
+        {
+            id: 0,
+            level: 1,
+            resources: 0,
+            resourceId: initialResources[0].id,
+            y: SHAFT_POSITION_Y_OFFSET,
+            managerLevel: 0,
+            skillPoints: 0,
+            skillLevels: {},
+        },
     ],
     elevator: {
         level: 1,
@@ -72,7 +82,7 @@ export const INITIAL_GAME_STATE: GameState = {
         targetShaftId: null,
         managerLevel: 0,
         skillPoints: 0,
-        unlockedSkills: [],
+        skillLevels: {},
     },
     cart: {
         level: 1,
@@ -81,7 +91,7 @@ export const INITIAL_GAME_STATE: GameState = {
         status: CartStatus.Idle,
         managerLevel: 0,
         skillPoints: 0,
-        unlockedSkills: [],
+        skillLevels: {},
     },
     market: {
         level: 1,
@@ -89,7 +99,7 @@ export const INITIAL_GAME_STATE: GameState = {
         lastDepositAmount: 0,
         managerLevel: 0,
         skillPoints: 0,
-        unlockedSkills: [],
+        skillLevels: {},
     },
     resources: initialResources,
     autoUpgradeTarget: null,
@@ -97,25 +107,25 @@ export const INITIAL_GAME_STATE: GameState = {
 
 // --- Skill Definitions ---
 export const MINE_SHAFT_SKILLS = [
-    { id: MineShaftSkill.GEOLOGISTS_EYE, name: "Geologist's Eye", description: "2% chance on production to find a gem worth 50x this shaft's p/s." },
-    { id: MineShaftSkill.DEEPER_VEINS, name: "Deeper Veins", description: "Doubles the maximum resource storage of this shaft." },
-    { id: MineShaftSkill.ADVANCED_MACHINERY, name: "Advanced Machinery", description: "Increases this shaft's production by a permanent 25%." }
+    { id: MineShaftSkill.GEOLOGISTS_EYE, name: "Geologist's Eye", description: "Adds a 2% chance per level to discover gems worth 50x production times the skill level." },
+    { id: MineShaftSkill.DEEPER_VEINS, name: "Deeper Veins", description: "Increases this shaft's storage capacity by 100% per level." },
+    { id: MineShaftSkill.ADVANCED_MACHINERY, name: "Advanced Machinery", description: "Boosts this shaft's production by 25% per level." }
 ];
 
 export const ELEVATOR_SKILLS = [
-    { id: ElevatorSkill.EXPRESS_LOAD, name: "Express Load", description: "Reduces resource collection and deposit time by 50%." },
-    { id: ElevatorSkill.LIGHTWEIGHT_MATERIALS, name: "Lightweight Materials", description: "Increases the elevator's base movement speed by 20%." },
-    { id: ElevatorSkill.REINFORCED_FRAME, name: "Reinforced Frame", description: "Increases the elevator's carrying capacity by 25%." }
+    { id: ElevatorSkill.EXPRESS_LOAD, name: "Express Load", description: "Cuts elevator collect/deposit time—50% at level 1 and faster with each level." },
+    { id: ElevatorSkill.LIGHTWEIGHT_MATERIALS, name: "Lightweight Materials", description: "Increases the elevator's base movement speed by 20% per level." },
+    { id: ElevatorSkill.REINFORCED_FRAME, name: "Reinforced Frame", description: "Increases the elevator's carrying capacity by 25% per level." }
 ];
 
 export const CART_SKILLS = [
-    { id: CartSkill.OVERCLOCKED_PUMPS, name: "Overclocked Pumps", description: "Increases resource transport speed by 25%." },
-    { id: CartSkill.REINFORCED_PIPES, name: "Reinforced Pipes", description: "Increases pipeline transport capacity by 25%." },
-    { id: CartSkill.MATTER_DUPLICATOR, name: "Matter Duplicator", description: "2% chance on collection to double the resources gathered from elevator storage." }
+    { id: CartSkill.OVERCLOCKED_PUMPS, name: "Overclocked Pumps", description: "Increases pipeline transport speed by 25% per level." },
+    { id: CartSkill.REINFORCED_PIPES, name: "Reinforced Pipes", description: "Increases pipeline transport capacity by 25% per level." },
+    { id: CartSkill.MATTER_DUPLICATOR, name: "Matter Duplicator", description: "Adds a 2% chance per level to double resources collected from the elevator." }
 ];
 
 export const MARKET_SKILLS = [
-    { id: MarketSkill.MASTER_NEGOTIATOR, name: "Master Negotiator", description: "5% chance to sell resources for double their value." },
-    { id: MarketSkill.EXPANDED_STORAGE, name: "Market Insight", description: "Increases the value of all sold resources by a permanent 25%." },
-    { id: MarketSkill.EFFICIENT_LOGISTICS, name: "Logistical Genius", description: "The pipeline cart instantly deposits resources at the market." }
+    { id: MarketSkill.MASTER_NEGOTIATOR, name: "Master Negotiator", description: "Adds a 5% chance per level to negotiate sales worth 2x value plus extra at higher levels." },
+    { id: MarketSkill.EXPANDED_STORAGE, name: "Market Insight", description: "Increases the value of sold resources by 25% per level." },
+    { id: MarketSkill.EFFICIENT_LOGISTICS, name: "Logistical Genius", description: "Reduces pipeline deposit time by 60% at level 1 and reaches instant deposits at max level." }
 ];

--- a/services/gameService.ts
+++ b/services/gameService.ts
@@ -34,13 +34,33 @@ export const loadGame = (): SavedGame | null => {
 
                 parsed.gameState.mineShafts.forEach((shaft: any) => {
                     if (shaft.skillPoints === undefined) shaft.skillPoints = 0;
-                    if (shaft.unlockedSkills === undefined) shaft.unlockedSkills = [];
+                    if (shaft.skillLevels === undefined) {
+                        shaft.skillLevels = {};
+                    }
+                    if (Array.isArray(shaft.unlockedSkills)) {
+                        shaft.unlockedSkills.forEach((skill: string) => {
+                            if (shaft.skillLevels[skill] === undefined) {
+                                shaft.skillLevels[skill] = 1;
+                            }
+                        });
+                        delete shaft.unlockedSkills;
+                    }
                     if (shaft.resourceId === undefined) shaft.resourceId = parsed.gameState.resources[0].id;
                 });
 
                 if (parsed.gameState.elevator) {
                     if (parsed.gameState.elevator.skillPoints === undefined) parsed.gameState.elevator.skillPoints = 0;
-                    if (parsed.gameState.elevator.unlockedSkills === undefined) parsed.gameState.elevator.unlockedSkills = [];
+                    if (parsed.gameState.elevator.skillLevels === undefined) {
+                        parsed.gameState.elevator.skillLevels = {};
+                    }
+                    if (Array.isArray(parsed.gameState.elevator.unlockedSkills)) {
+                        parsed.gameState.elevator.unlockedSkills.forEach((skill: string) => {
+                            if (parsed.gameState.elevator.skillLevels[skill] === undefined) {
+                                parsed.gameState.elevator.skillLevels[skill] = 1;
+                            }
+                        });
+                        delete parsed.gameState.elevator.unlockedSkills;
+                    }
                     if (parsed.gameState.elevator.storage === undefined) parsed.gameState.elevator.storage = {};
                     // Convert old `load: number` to `load: ResourceMap`
                     if (typeof parsed.gameState.elevator.load === 'number') {
@@ -57,7 +77,17 @@ export const loadGame = (): SavedGame | null => {
 
                 if (parsed.gameState.market) {
                     if (parsed.gameState.market.skillPoints === undefined) parsed.gameState.market.skillPoints = 0;
-                    if (parsed.gameState.market.unlockedSkills === undefined) parsed.gameState.market.unlockedSkills = [];
+                    if (parsed.gameState.market.skillLevels === undefined) {
+                        parsed.gameState.market.skillLevels = {};
+                    }
+                    if (Array.isArray(parsed.gameState.market.unlockedSkills)) {
+                        parsed.gameState.market.unlockedSkills.forEach((skill: string) => {
+                            if (parsed.gameState.market.skillLevels[skill] === undefined) {
+                                parsed.gameState.market.skillLevels[skill] = 1;
+                            }
+                        });
+                        delete parsed.gameState.market.unlockedSkills;
+                    }
                     // Convert old `resources: number` to `resources: ResourceMap`
                     if (typeof parsed.gameState.market.resources === 'number') {
                         const defaultResourceId = parsed.gameState.resources[0].id;
@@ -74,13 +104,21 @@ export const loadGame = (): SavedGame | null => {
                         status: CartStatus.Idle,
                         managerLevel: 0,
                         skillPoints: 0,
-                        unlockedSkills: [],
+                        skillLevels: {},
                     };
                 } else {
                     // Migration: Add manager fields to existing cart
                     if (parsed.gameState.cart.managerLevel === undefined) parsed.gameState.cart.managerLevel = 0;
                     if (parsed.gameState.cart.skillPoints === undefined) parsed.gameState.cart.skillPoints = 0;
-                    if (parsed.gameState.cart.unlockedSkills === undefined) parsed.gameState.cart.unlockedSkills = [];
+                    if (parsed.gameState.cart.skillLevels === undefined) parsed.gameState.cart.skillLevels = {};
+                    if (Array.isArray(parsed.gameState.cart.unlockedSkills)) {
+                        parsed.gameState.cart.unlockedSkills.forEach((skill: string) => {
+                            if (parsed.gameState.cart.skillLevels[skill] === undefined) {
+                                parsed.gameState.cart.skillLevels[skill] = 1;
+                            }
+                        });
+                        delete parsed.gameState.cart.unlockedSkills;
+                    }
                 }
 
                 if (parsed.gameState.autoUpgradeTarget === undefined) {

--- a/types.ts
+++ b/types.ts
@@ -34,6 +34,8 @@ export enum MarketSkill {
     EFFICIENT_LOGISTICS = 'efficient-logistics',
 }
 
+export type SkillLevels<T extends string> = Partial<Record<T, number>>;
+
 // --- Game State ---
 export type ResourceMap = { [resourceId: string]: number };
 
@@ -45,7 +47,7 @@ export interface MineShaftState {
     y: number;
     managerLevel: number;
     skillPoints: number;
-    unlockedSkills: MineShaftSkill[];
+    skillLevels: SkillLevels<MineShaftSkill>;
 }
 
 export enum ElevatorStatus {
@@ -65,7 +67,7 @@ export interface ElevatorState {
     targetShaftId: number | null;
     managerLevel: number;
     skillPoints: number;
-    unlockedSkills: ElevatorSkill[];
+    skillLevels: SkillLevels<ElevatorSkill>;
     actionTimer?: number;
 }
 
@@ -85,7 +87,7 @@ export interface CartState {
     actionTimer?: number;
     managerLevel: number;
     skillPoints: number;
-    unlockedSkills: CartSkill[];
+    skillLevels: SkillLevels<CartSkill>;
 }
 
 export interface MarketState {
@@ -94,7 +96,7 @@ export interface MarketState {
     lastDepositAmount: number;
     managerLevel: number;
     skillPoints: number;
-    unlockedSkills: MarketSkill[];
+    skillLevels: SkillLevels<MarketSkill>;
 }
 
 export interface GameState {


### PR DESCRIPTION
## Summary
- add per-skill level tracking with scaling production, speed, and value bonuses across the game systems
- migrate save data and initial state to use skill level maps with a five-level cap
- refresh the manager skill modal UI to show skill levels, availability, and maxed states

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3bc157448832fbaf6ca01ad58e2be