### PR TITLE
Replace miner component with new sprite asset

### DIFF
--- a/components/Miner.tsx
+++ b/components/Miner.tsx
@@ -1,32 +1,26 @@
 import React from 'react';
-import { MinerIcon } from './icons';
+import southFacingMiner from '../assets/miner/rotations/south.png';
 
 const Miner: React.FC = () => {
     return (
-        <div className="relative w-20 h-20 miner-container">
+        <div className="relative w-20 h-20 miner-container flex items-center justify-center">
             <style>
                 {`
-                    @keyframes mine-swing-animation {
-                        0% { transform: rotate(15deg); }
-                        50% { transform: rotate(-30deg); }
-                        100% { transform: rotate(15deg); }
-                    }
-                    .miner-container .miner-arm-pickaxe {
-                        animation: mine-swing-animation 1.2s ease-in-out infinite;
-                        transform-origin: 38px 36px; /* Approx shoulder point */
-                    }
-
                     @keyframes miner-bob-animation {
                         0%, 100% { transform: translateY(0px); }
-                        50% { transform: translateY(-3px); }
+                        50% { transform: translateY(-4px); }
                     }
-                    .miner-container .miner-body-group {
+
+                    .miner-container .miner-sprite {
                         animation: miner-bob-animation 2.2s ease-in-out infinite;
+                        image-rendering: pixelated;
+                        width: 100%;
+                        height: 100%;
+                        object-fit: contain;
                     }
                 `}
             </style>
-            {/* The actual character icon */}
-            <MinerIcon className="w-full h-full" />
+            <img src={southFacingMiner} alt="Miner character" className="miner-sprite" />
         </div>
     );
 };

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+    const value: string;
+    export default value;
+}


### PR DESCRIPTION
## Summary
- swap the miner SVG icon for the new south-facing sprite added under assets and keep a subtle bob animation
- ensure the sprite renders crisply with pixelated scaling while remaining centered in its container
- add a global declaration so TypeScript understands PNG imports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4540ea730832f9f374a3ebe25f533