### PR TITLE
Animate miner rotations from metadata

### DIFF
--- a/components/Miner.tsx
+++ b/components/Miner.tsx
@@ -1,7 +1,40 @@
-import React from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import southFacingMiner from '../assets/miner/rotations/south.png';
+import minerMetadata from '../assets/miner/metadata.json';
+
+type MinerMetadata = {
+    frames?: {
+        rotations?: Record<string, string>;
+    };
+};
 
 const Miner: React.FC = () => {
+    const rotations = useMemo(() => {
+        const typedMetadata = minerMetadata as MinerMetadata;
+        const rotationEntries = Object.entries(typedMetadata.frames?.rotations ?? {});
+
+        return rotationEntries.map(([direction, relativePath]) => ({
+            direction,
+            src: new URL(`../assets/miner/${relativePath}`, import.meta.url).href,
+        }));
+    }, []);
+
+    const [currentRotationIndex, setCurrentRotationIndex] = useState(0);
+
+    useEffect(() => {
+        if (rotations.length <= 1) {
+            return;
+        }
+
+        const intervalId = window.setInterval(() => {
+            setCurrentRotationIndex((prevIndex) => (prevIndex + 1) % rotations.length);
+        }, 1000);
+
+        return () => window.clearInterval(intervalId);
+    }, [rotations.length]);
+
+    const currentRotation = rotations[currentRotationIndex];
+
     return (
         <div className="relative w-20 h-20 miner-container flex items-center justify-center">
             <style>
@@ -20,7 +53,11 @@ const Miner: React.FC = () => {
                     }
                 `}
             </style>
-            <img src={southFacingMiner} alt="Miner character" className="miner-sprite" />
+            <img
+                src={currentRotation?.src ?? southFacingMiner}
+                alt={`Miner character facing ${currentRotation?.direction ?? 'south'}`}
+                className="miner-sprite"
+            />
         </div>
     );
 };

--- a/global.d.ts
+++ b/global.d.ts
@@ -2,3 +2,8 @@ declare module '*.png' {
     const value: string;
     export default value;
 }
+
+declare module '*.json' {
+    const value: unknown;
+    export default value;
+}


### PR DESCRIPTION
## Summary
- animate the miner sprite by cycling through each facing defined in the metadata JSON
- add a JSON module declaration so the TypeScript compiler accepts the metadata import

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d45545921c832fbf1c54a4ddd8ba3d