### PR TITLE
Fix miner sprite rotation asset loading

### DIFF
--- a/components/Miner.tsx
+++ b/components/Miner.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import southFacingMiner from '../assets/miner/rotations/south.png';
+import northFacingMiner from '../assets/miner/rotations/north.png';
+import eastFacingMiner from '../assets/miner/rotations/east.png';
+import westFacingMiner from '../assets/miner/rotations/west.png';
 import minerMetadata from '../assets/miner/metadata.json';
 
 type MinerMetadata = {
@@ -13,9 +16,16 @@ const Miner: React.FC = () => {
         const typedMetadata = minerMetadata as MinerMetadata;
         const rotationEntries = Object.entries(typedMetadata.frames?.rotations ?? {});
 
-        return rotationEntries.map(([direction, relativePath]) => ({
+        const rotationImageMap: Record<string, string> = {
+            south: southFacingMiner,
+            north: northFacingMiner,
+            east: eastFacingMiner,
+            west: westFacingMiner,
+        };
+
+        return rotationEntries.map(([direction]) => ({
             direction,
-            src: new URL(`../assets/miner/${relativePath}`, import.meta.url).href,
+            src: rotationImageMap[direction] ?? southFacingMiner,
         }));
     }, []);
 


### PR DESCRIPTION
## Summary
- load miner rotation sprites from static imports instead of dynamic URL construction
- fall back to the south-facing sprite if an unexpected direction is requested

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d457922474832f94c6f67aecf336e4